### PR TITLE
perf: use sequences instead of lists in Evaluator

### DIFF
--- a/semgus-sketch/src/main/java/org/semgus/sketch/util/Translator.kt
+++ b/semgus-sketch/src/main/java/org/semgus/sketch/util/Translator.kt
@@ -36,7 +36,7 @@ internal fun SemgusProblem.toSketchProblem(): Problem {
       fn = id(target.nt.name) { withSem() },
       args = es.filterNot {
         it is Expr.Ref && it.id.name == target.name
-      }.asSequence(),
+      },
     )
   }
   fns[target.name] = { refPlain(target.name) }


### PR DESCRIPTION
This avoids calling `toList` too much.